### PR TITLE
Singly and Doubly Linked List Move Semantics

### DIFF
--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
@@ -314,7 +314,7 @@ std::optional<ElementType> DoublyLinkedList<ElementType>::removeAtHead() noexcep
 		headNode->setPreviousNode(nullptr);
 	}
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>
@@ -335,7 +335,7 @@ std::optional<ElementType> DoublyLinkedList<ElementType>::removeAtTail() noexcep
 	tailNode->setNextNode(nullptr);
 	--nodeCount;
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>
@@ -364,7 +364,7 @@ std::optional<ElementType> DoublyLinkedList<ElementType>::removeAtIndex(const st
 	delete node;
 	--nodeCount;
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
@@ -43,8 +43,11 @@ public:
 
 public:
 	void insertAtHead(const ElementType& element) noexcept;
+	void insertAtHead(ElementType&& element) noexcept;
 	void insertAtTail(const ElementType& element) noexcept;
+	void insertAtTail(ElementType&& element) noexcept;
 	const bool insertAtIndex(const ElementType& element, const std::size_t index) noexcept;
+	const bool insertAtIndex(ElementType&& element, const std::size_t index) noexcept;
 	std::optional<ElementType> removeAtHead() noexcept;
 	std::optional<ElementType> removeAtTail() noexcept;
 	std::optional<ElementType> removeAtIndex(const std::size_t index) noexcept;
@@ -184,8 +187,40 @@ void DoublyLinkedList<ElementType>::insertAtHead(const ElementType& element) noe
 }
 
 template<typename ElementType>
+void DoublyLinkedList<ElementType>::insertAtHead(ElementType&& element) noexcept {
+	auto* node {new DoublyLinkedListNode<ElementType>(std::move(element))};
+	
+	if (headNode == nullptr) {
+		headNode = node;
+		tailNode = node;
+	} else {
+		node->setNextNode(headNode);
+		headNode->setPreviousNode(node);
+		headNode = node;
+	}
+	
+	++nodeCount;
+}
+
+template<typename ElementType>
 void DoublyLinkedList<ElementType>::insertAtTail(const ElementType& element) noexcept {
 	auto* node {new DoublyLinkedListNode<ElementType>(element)};
+	
+	if (tailNode == nullptr) {
+		headNode = node;
+		tailNode = node;
+	} else {
+		node->setPreviousNode(tailNode);
+		tailNode->setNextNode(node);
+		tailNode = node;
+	}
+	
+	++nodeCount;
+}
+
+template<typename ElementType>
+void DoublyLinkedList<ElementType>::insertAtTail(ElementType&& element) noexcept {
+	auto* node {new DoublyLinkedListNode<ElementType>(std::move(element))};
 	
 	if (tailNode == nullptr) {
 		headNode = node;
@@ -216,6 +251,37 @@ const bool DoublyLinkedList<ElementType>::insertAtIndex(const ElementType& eleme
 	}
 	
 	auto* node {new DoublyLinkedListNode<ElementType>(element)};
+	auto* previousNode {headNode};
+	for (std::size_t currentIndex {0}; currentIndex < index - 1; ++currentIndex) {
+		previousNode = previousNode->getNextNode();
+	}
+	
+	node->setNextNode(previousNode->getNextNode());
+	node->setPreviousNode(previousNode);
+	node->getNextNode()->setPreviousNode(node);
+	previousNode->setNextNode(node);
+	++nodeCount;
+	
+	return true;
+}
+
+template<typename ElementType>
+const bool DoublyLinkedList<ElementType>::insertAtIndex(ElementType&& element, const std::size_t index) noexcept {
+	if (index > nodeCount) {
+		return false;
+	}
+	
+	if (index == 0 || headNode == nullptr) {
+		insertAtHead(std::move(element));
+		return true;
+	}
+	
+	if (index == nodeCount) {
+		insertAtTail(std::move(element));
+		return true;
+	}
+	
+	auto* node {new DoublyLinkedListNode<ElementType>(std::move(element))};
 	auto* previousNode {headNode};
 	for (std::size_t currentIndex {0}; currentIndex < index - 1; ++currentIndex) {
 		previousNode = previousNode->getNextNode();

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
@@ -42,12 +42,12 @@ public:
 	ReverseBidirectionalIterator rend() const noexcept;
 
 public:
-	void insertAtHead(const ElementType& element) noexcept;
-	void insertAtHead(ElementType&& element) noexcept;
-	void insertAtTail(const ElementType& element) noexcept;
-	void insertAtTail(ElementType&& element) noexcept;
-	const bool insertAtIndex(const ElementType& element, const std::size_t index) noexcept;
-	const bool insertAtIndex(ElementType&& element, const std::size_t index) noexcept;
+	void insertAtHead(const ElementType& element);
+	void insertAtHead(ElementType&& element);
+	void insertAtTail(const ElementType& element);
+	void insertAtTail(ElementType&& element);
+	const bool insertAtIndex(const ElementType& element, const std::size_t index);
+	const bool insertAtIndex(ElementType&& element, const std::size_t index);
 	std::optional<ElementType> removeAtHead() noexcept;
 	std::optional<ElementType> removeAtTail() noexcept;
 	std::optional<ElementType> removeAtIndex(const std::size_t index) noexcept;
@@ -171,7 +171,7 @@ DoublyLinkedList<ElementType>::ReverseBidirectionalIterator DoublyLinkedList<Ele
 }
 
 template<typename ElementType>
-void DoublyLinkedList<ElementType>::insertAtHead(const ElementType& element) noexcept {
+void DoublyLinkedList<ElementType>::insertAtHead(const ElementType& element) {
 	auto* node {new DoublyLinkedListNode<ElementType>(element)};
 	
 	if (headNode == nullptr) {
@@ -187,7 +187,7 @@ void DoublyLinkedList<ElementType>::insertAtHead(const ElementType& element) noe
 }
 
 template<typename ElementType>
-void DoublyLinkedList<ElementType>::insertAtHead(ElementType&& element) noexcept {
+void DoublyLinkedList<ElementType>::insertAtHead(ElementType&& element) {
 	auto* node {new DoublyLinkedListNode<ElementType>(std::move(element))};
 	
 	if (headNode == nullptr) {
@@ -203,7 +203,7 @@ void DoublyLinkedList<ElementType>::insertAtHead(ElementType&& element) noexcept
 }
 
 template<typename ElementType>
-void DoublyLinkedList<ElementType>::insertAtTail(const ElementType& element) noexcept {
+void DoublyLinkedList<ElementType>::insertAtTail(const ElementType& element) {
 	auto* node {new DoublyLinkedListNode<ElementType>(element)};
 	
 	if (tailNode == nullptr) {
@@ -219,7 +219,7 @@ void DoublyLinkedList<ElementType>::insertAtTail(const ElementType& element) noe
 }
 
 template<typename ElementType>
-void DoublyLinkedList<ElementType>::insertAtTail(ElementType&& element) noexcept {
+void DoublyLinkedList<ElementType>::insertAtTail(ElementType&& element) {
 	auto* node {new DoublyLinkedListNode<ElementType>(std::move(element))};
 	
 	if (tailNode == nullptr) {
@@ -235,7 +235,7 @@ void DoublyLinkedList<ElementType>::insertAtTail(ElementType&& element) noexcept
 }
 
 template<typename ElementType>
-const bool DoublyLinkedList<ElementType>::insertAtIndex(const ElementType& element, const std::size_t index) noexcept {
+const bool DoublyLinkedList<ElementType>::insertAtIndex(const ElementType& element, const std::size_t index) {
 	if (index > nodeCount) {
 		return false;
 	}
@@ -266,7 +266,7 @@ const bool DoublyLinkedList<ElementType>::insertAtIndex(const ElementType& eleme
 }
 
 template<typename ElementType>
-const bool DoublyLinkedList<ElementType>::insertAtIndex(ElementType&& element, const std::size_t index) noexcept {
+const bool DoublyLinkedList<ElementType>::insertAtIndex(ElementType&& element, const std::size_t index) {
 	if (index > nodeCount) {
 		return false;
 	}

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
@@ -370,10 +370,19 @@ std::optional<ElementType> DoublyLinkedList<ElementType>::removeAtIndex(const st
 template<typename ElementType>
 std::vector<ElementType> DoublyLinkedList<ElementType>::removeAll() noexcept {
 	std::vector<ElementType> elements {};
+	elements.reserve(nodeCount);
 	
-	while (headNode != nullptr) {
-		elements.emplace_back(removeAtHead().value());
+	auto currentNode {headNode};
+	while (currentNode != nullptr) {
+		elements.emplace_back(currentNode->getElement());
+		auto* node {currentNode};
+		currentNode = currentNode->getNextNode();
+		delete node;
 	}
+	
+	nodeCount = 0;
+	headNode = nullptr;
+	tailNode = nullptr;
 	
 	return elements;
 }

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
@@ -5,6 +5,9 @@ template<typename ElementType>
 class DoublyLinkedListNode final {
 public:
 	explicit DoublyLinkedListNode(const ElementType& element) noexcept;
+	explicit DoublyLinkedListNode(ElementType&& element) noexcept;
+	DoublyLinkedListNode(const DoublyLinkedListNode<ElementType>& other) noexcept = default;
+	DoublyLinkedListNode(DoublyLinkedListNode<ElementType>&& other) noexcept = default;
 
 public:
 	const bool operator==(const DoublyLinkedListNode<ElementType>& other) const noexcept;
@@ -27,6 +30,11 @@ private:
 
 template<typename ElementType>
 DoublyLinkedListNode<ElementType>::DoublyLinkedListNode(const ElementType& element) noexcept : element(element) {
+
+}
+
+template<typename ElementType>
+DoublyLinkedListNode<ElementType>::DoublyLinkedListNode(ElementType&& element) noexcept : element {std::move(element)} {
 
 }
 

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
@@ -8,6 +8,7 @@ public:
 	explicit DoublyLinkedListNode(ElementType&& element) noexcept;
 	DoublyLinkedListNode(const DoublyLinkedListNode<ElementType>& other) noexcept = default;
 	DoublyLinkedListNode(DoublyLinkedListNode<ElementType>&& other) noexcept = default;
+	~DoublyLinkedListNode() noexcept = default;
 
 public:
 	const bool operator==(const DoublyLinkedListNode<ElementType>& other) const noexcept;

--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedListNode.hpp
@@ -11,6 +11,8 @@ public:
 	~DoublyLinkedListNode() noexcept = default;
 
 public:
+	DoublyLinkedListNode<ElementType>& operator=(const DoublyLinkedListNode<ElementType>& other) noexcept = default;
+	DoublyLinkedListNode<ElementType>& operator=(DoublyLinkedListNode<ElementType>&& other) noexcept = default;
 	const bool operator==(const DoublyLinkedListNode<ElementType>& other) const noexcept;
 
 public:

--- a/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
@@ -334,10 +334,19 @@ std::optional<ElementType> SinglyLinkedList<ElementType>::removeAtIndex(const st
 template<typename ElementType>
 std::vector<ElementType> SinglyLinkedList<ElementType>::removeAll() noexcept {
 	std::vector<ElementType> elements {};
+	elements.reserve(nodeCount);
 	
-	while (headNode != nullptr) {
-		elements.emplace_back(removeAtHead().value());
+	auto currentNode {headNode};
+	while (currentNode != nullptr) {
+		elements.push_back(currentNode->getElement());
+		auto* node {currentNode};
+		currentNode = currentNode->getNextNode();
+		delete node;
 	}
+	
+	nodeCount = 0;
+	headNode = nullptr;
+	tailNode = nullptr;
 	
 	return elements;
 }

--- a/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
@@ -35,8 +35,11 @@ public:
 
 public:
 	void insertAtHead(const ElementType& element);
+	void insertAtHead(ElementType&& element);
 	void insertAtTail(const ElementType& element);
+	void insertAtTail(ElementType&& element);
 	const bool insertAtIndex(const ElementType& element, const std::size_t index);
+	const bool insertAtIndex(ElementType&& element, const std::size_t index);
 	std::optional<ElementType> removeAtHead() noexcept;
 	std::optional<ElementType> removeAtTail() noexcept;
 	std::optional<ElementType> removeAtIndex(const std::size_t index) noexcept;
@@ -153,8 +156,38 @@ void SinglyLinkedList<ElementType>::insertAtHead(const ElementType& element) {
 }
 
 template<typename ElementType>
+void SinglyLinkedList<ElementType>::insertAtHead(ElementType&& element) {
+	auto* node {new SinglyLinkedListNode<ElementType> {std::move(element)}};
+	
+	if (headNode == nullptr) {
+		headNode = node;
+		tailNode = node;
+	} else {
+		node->setNextNode(headNode);
+		headNode = node;
+	}
+	
+	++nodeCount;
+}
+
+template<typename ElementType>
 void SinglyLinkedList<ElementType>::insertAtTail(const ElementType& element) {
 	auto* node {new SinglyLinkedListNode<ElementType> {element}};
+	
+	if (headNode == nullptr) {
+		headNode = node;
+		tailNode = node;
+	} else {
+		tailNode->setNextNode(node);
+		tailNode = node;
+	}
+	
+	++nodeCount;
+}
+
+template<typename ElementType>
+void SinglyLinkedList<ElementType>::insertAtTail(ElementType&& element) {
+	auto* node {new SinglyLinkedListNode<ElementType> {std::move(element)}};
 	
 	if (headNode == nullptr) {
 		headNode = node;
@@ -184,6 +217,36 @@ const bool SinglyLinkedList<ElementType>::insertAtIndex(const ElementType& eleme
 	}
 	
 	auto* node {new SinglyLinkedListNode<ElementType> {element}};
+	
+	auto* previousNode {headNode};
+	for (std::size_t currentIndex {0}; currentIndex < index - 1; ++currentIndex) {
+		previousNode = previousNode->getNextNode();
+	}
+	
+	node->setNextNode(previousNode->getNextNode());
+	previousNode->setNextNode(node);
+	++nodeCount;
+	
+	return true;
+}
+
+template<typename ElementType>
+const bool SinglyLinkedList<ElementType>::insertAtIndex(ElementType&& element, const std::size_t index) {
+	if (index > nodeCount) {
+		return false;
+	}
+	
+	if (index == 0 || headNode == nullptr) {
+		insertAtHead(std::move(element));
+		return true;
+	}
+	
+	if (index == nodeCount) {
+		insertAtTail(std::move(element));
+		return true;
+	}
+	
+	auto* node {new SinglyLinkedListNode<ElementType> {std::move(element)}};
 	
 	auto* previousNode {headNode};
 	for (std::size_t currentIndex {0}; currentIndex < index - 1; ++currentIndex) {

--- a/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
@@ -34,9 +34,9 @@ public:
 	ForwardIterator end() const noexcept;
 
 public:
-	void insertAtHead(const ElementType& element) noexcept;
-	void insertAtTail(const ElementType& element) noexcept;
-	const bool insertAtIndex(const ElementType& element, const std::size_t index) noexcept;
+	void insertAtHead(const ElementType& element);
+	void insertAtTail(const ElementType& element);
+	const bool insertAtIndex(const ElementType& element, const std::size_t index);
 	std::optional<ElementType> removeAtHead() noexcept;
 	std::optional<ElementType> removeAtTail() noexcept;
 	std::optional<ElementType> removeAtIndex(const std::size_t index) noexcept;
@@ -138,7 +138,7 @@ SinglyLinkedList<ElementType>::ForwardIterator SinglyLinkedList<ElementType>::en
 }
 
 template<typename ElementType>
-void SinglyLinkedList<ElementType>::insertAtHead(const ElementType& element) noexcept {
+void SinglyLinkedList<ElementType>::insertAtHead(const ElementType& element) {
 	auto* node {new SinglyLinkedListNode<ElementType> {element}};
 	
 	if (headNode == nullptr) {
@@ -153,7 +153,7 @@ void SinglyLinkedList<ElementType>::insertAtHead(const ElementType& element) noe
 }
 
 template<typename ElementType>
-void SinglyLinkedList<ElementType>::insertAtTail(const ElementType& element) noexcept {
+void SinglyLinkedList<ElementType>::insertAtTail(const ElementType& element) {
 	auto* node {new SinglyLinkedListNode<ElementType> {element}};
 	
 	if (headNode == nullptr) {
@@ -168,7 +168,7 @@ void SinglyLinkedList<ElementType>::insertAtTail(const ElementType& element) noe
 }
 
 template<typename ElementType>
-const bool SinglyLinkedList<ElementType>::insertAtIndex(const ElementType& element, const std::size_t index) noexcept {
+const bool SinglyLinkedList<ElementType>::insertAtIndex(const ElementType& element, const std::size_t index) {
 	if (index > nodeCount) {
 		return false;
 	}

--- a/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
@@ -276,7 +276,7 @@ std::optional<ElementType> SinglyLinkedList<ElementType>::removeAtHead() noexcep
 		tailNode = nullptr;
 	}
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>
@@ -300,7 +300,7 @@ std::optional<ElementType> SinglyLinkedList<ElementType>::removeAtTail() noexcep
 	tailNode->setNextNode(nullptr);
 	--nodeCount;
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>
@@ -328,7 +328,7 @@ std::optional<ElementType> SinglyLinkedList<ElementType>::removeAtIndex(const st
 	delete node;
 	--nodeCount;
 	
-	return element;
+	return std::move(element);
 }
 
 template<typename ElementType>


### PR DESCRIPTION
# Overview
The singly and doubly linked lists now further support move semantics with the insertion and removal methods. The `removeAll` method was also optimized.