### PR TITLE
Singly and Doubly Linked List Reversal

### DIFF
--- a/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/DoublyLinkedList.hpp
@@ -56,6 +56,7 @@ public:
 	BidirectionalIterator findFirst(const std::function<bool(const ElementType&)>& predicate) noexcept;
 	ConstReverseBidirectionalIterator findLast(const std::function<bool(const ElementType&)>& predicate) const noexcept;
 	ReverseBidirectionalIterator findLast(const std::function<bool(const ElementType&)>& predicate) noexcept;
+	void reverse() noexcept;
 	const bool contains(const std::function<bool(const ElementType&)>& predicate) const noexcept;
 	const bool containsAll(const std::vector<std::function<bool(const ElementType&)>>& predicates) const noexcept;
 	const bool isEmpty() const noexcept;
@@ -405,6 +406,26 @@ DoublyLinkedList<ElementType>::ConstReverseBidirectionalIterator DoublyLinkedLis
 template<typename ElementType>
 DoublyLinkedList<ElementType>::ReverseBidirectionalIterator DoublyLinkedList<ElementType>::findLast(const std::function<bool(const ElementType&)>& predicate) noexcept {
 	return std::find_if(rbegin(), rend(), predicate);
+}
+
+template<typename ElementType>
+void DoublyLinkedList<ElementType>::reverse() noexcept {
+	if (headNode == nullptr || tailNode == nullptr) {
+		return;
+	}
+	
+	DoublyLinkedListNode<ElementType>* currentNode {headNode};
+	DoublyLinkedListNode<ElementType>* tempNode {nullptr};
+	while (currentNode != nullptr) {
+		tempNode = currentNode->getPreviousNode();
+		currentNode->setPreviousNode(currentNode->getNextNode());
+		currentNode->setNextNode(tempNode);
+		currentNode = currentNode->getPreviousNode();
+	}
+	
+	tempNode = headNode;
+	headNode = tailNode;
+	tailNode = tempNode;
 }
 
 template<typename ElementType>

--- a/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
+++ b/Core/Include/DataStructures/LinkedLists/SinglyLinkedList.hpp
@@ -46,6 +46,7 @@ public:
 	std::vector<ElementType> removeAll() noexcept;
 	ConstForwardIterator findFirst(const std::function<bool(const ElementType&)>& predicate) const noexcept;
 	ForwardIterator findFirst(const std::function<bool(const ElementType&)>& predicate) noexcept;
+	void reverse() noexcept;
 	const bool contains(const std::function<bool(const ElementType&)>& predicate) const noexcept;
 	const bool containsAll(const std::vector<std::function<bool(const ElementType&)>>& predicates) const noexcept;
 	const bool isEmpty() const noexcept;
@@ -359,6 +360,28 @@ SinglyLinkedList<ElementType>::ConstForwardIterator SinglyLinkedList<ElementType
 template<typename ElementType>
 SinglyLinkedList<ElementType>::ForwardIterator SinglyLinkedList<ElementType>::findFirst(const std::function<bool(const ElementType&)>& predicate) noexcept {
 	return std::find_if(begin(), end(), predicate);
+}
+
+template<typename ElementType>
+void SinglyLinkedList<ElementType>::reverse() noexcept {
+	if (headNode == nullptr || headNode == tailNode) {
+		return;
+	}
+	
+	SinglyLinkedListNode<ElementType>* previousNode {nullptr};
+	SinglyLinkedListNode<ElementType>* currentNode {headNode};
+	SinglyLinkedListNode<ElementType>* nextNode {nullptr};
+	
+	while (currentNode != nullptr) {
+		nextNode = currentNode->getNextNode();
+		currentNode->setNextNode(previousNode);
+		previousNode = currentNode;
+		currentNode = nextNode;
+	}
+	
+	
+	tailNode = headNode;
+	headNode = previousNode;
 }
 
 template<typename ElementType>

--- a/Test/Source/DataStructures/LinkedLists/NonEmptyIntegerDoublyLinkedList.cpp
+++ b/Test/Source/DataStructures/LinkedLists/NonEmptyIntegerDoublyLinkedList.cpp
@@ -326,6 +326,12 @@ TEST_F(NonEmptyIntegerDoublyLinkedList, GivenPredicateMatchingNoElements_WhenFin
 	EXPECT_THAT(result, testing::Eq(doublyLinkedList.rend()));
 }
 
+TEST_F(NonEmptyIntegerDoublyLinkedList, GivenNonEmptyIntegerDoublyLinkedList_WhenReverse_ThenElementsAreInExpectedOrder) {
+	doublyLinkedList.reverse();
+	
+	EXPECT_THAT(doublyLinkedList, testing::ElementsAre(50, 40, 30, 20, 10));
+}
+
 TEST_F(NonEmptyIntegerDoublyLinkedList, GivenPredicateMatchingAtLeastOneElement_WhenContains_ThenReturnsTrue) {
 	const auto result {doublyLinkedList.contains(::Test::isThirty)};
 	

--- a/Test/Source/DataStructures/LinkedLists/NonEmptyIntegerSinglyLinkedListTest.cpp
+++ b/Test/Source/DataStructures/LinkedLists/NonEmptyIntegerSinglyLinkedListTest.cpp
@@ -26,6 +26,12 @@ TEST_F(NonEmptyIntegerSinglyLinkedListTest,
 	EXPECT_THAT(otherSinglyLinkedList, testing::Eq(singlyLinkedList));
 }
 
+TEST_F(NonEmptyIntegerSinglyLinkedListTest, GivenNonEmptyIntegerSinglyLinkedList_WhenReverse_ThenElementsAreInExpectedOrder) {
+	singlyLinkedList.reverse();
+	
+	EXPECT_THAT(singlyLinkedList, testing::ElementsAre(50, 40, 30, 20, 10));
+}
+
 TEST_F(NonEmptyIntegerSinglyLinkedListTest,
        GivenNonEmptyIntegerSinglyLinkedList_WhenMoveConstruct_ThenNewSinglyLinkedListContainsElementsFromOriginal) {
 	const auto otherSinglyLinkedList {std::move(singlyLinkedList)};


### PR DESCRIPTION
# Overview
The `reverse` method was implemented in the singly and doubly linked lists which reverses the order of the linked list.