### PR TITLE
Merge Sort

### DIFF
--- a/Core/Include/Algorithms/Sorting/BubbleSorter.hpp
+++ b/Core/Include/Algorithms/Sorting/BubbleSorter.hpp
@@ -10,13 +10,13 @@ template<ArrayOrVectorConcept Container>
 class BubbleSorter final : public SortingAlgorithm<typename Container::value_type> {
 public:
 	explicit BubbleSorter(Container& container) noexcept;
-	BubbleSorter(const BubbleSorter& bubbleSorter) noexcept = delete;
-	BubbleSorter(BubbleSorter&& bubbleSorter) noexcept = delete;
+	BubbleSorter(const BubbleSorter& other) noexcept = delete;
+	BubbleSorter(BubbleSorter&& other) noexcept = delete;
 	~BubbleSorter() noexcept override = default;
 
 public:
-	BubbleSorter& operator=(const BubbleSorter& bubbleSorter) noexcept = delete;
-	BubbleSorter& operator=(BubbleSorter&& bubbleSorter) noexcept = delete;
+	BubbleSorter& operator=(const BubbleSorter& other) noexcept = delete;
+	BubbleSorter& operator=(BubbleSorter&& other) noexcept = delete;
 
 public:
 	virtual void sort(const std::function<bool(const typename Container::value_type&,

--- a/Core/Include/Algorithms/Sorting/CMakeLists.txt
+++ b/Core/Include/Algorithms/Sorting/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(HEADER_FILES
 		ArrayOrVectorConcept.hpp
 		BubbleSorter.hpp
 		InsertionSorter.hpp
+		MergeSorter.hpp
 		SortingAlgorithm.hpp)
 
 TARGET_SOURCES(${PROJECT_NAME} PRIVATE ${HEADER_FILES})

--- a/Core/Include/Algorithms/Sorting/InsertionSorter.hpp
+++ b/Core/Include/Algorithms/Sorting/InsertionSorter.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <algorithm>
-
 #include "ArrayOrVectorConcept.hpp"
 #include "SortingAlgorithm.hpp"
 

--- a/Core/Include/Algorithms/Sorting/InsertionSorter.hpp
+++ b/Core/Include/Algorithms/Sorting/InsertionSorter.hpp
@@ -8,13 +8,13 @@ template<ArrayOrVectorConcept Container>
 class InsertionSorter final : public SortingAlgorithm<typename Container::value_type> {
 public:
 	explicit InsertionSorter(Container& container) noexcept;
-	InsertionSorter(const InsertionSorter& insertionSorter) noexcept = delete;
-	InsertionSorter(InsertionSorter&& insertionSorter) noexcept = delete;
+	InsertionSorter(const InsertionSorter& other) noexcept = delete;
+	InsertionSorter(InsertionSorter&& other) noexcept = delete;
 	~InsertionSorter() noexcept override = default;
 
 public:
-	InsertionSorter& operator=(const InsertionSorter& insertionSorter) noexcept = delete;
-	InsertionSorter& operator=(InsertionSorter&& insertionSorter) noexcept = delete;
+	InsertionSorter& operator=(const InsertionSorter& other) noexcept = delete;
+	InsertionSorter& operator=(InsertionSorter&& other) noexcept = delete;
 
 public:
 	virtual void sort(const std::function<bool(const typename Container::value_type&,

--- a/Core/Include/Algorithms/Sorting/MergeSorter.hpp
+++ b/Core/Include/Algorithms/Sorting/MergeSorter.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "ArrayOrVectorConcept.hpp"
+#include "SortingAlgorithm.hpp"
+
+namespace Core::Algorithms::Sorting {
+template<ArrayOrVectorConcept Container>
+class MergeSorter final : public SortingAlgorithm<typename Container::value_type> {
+public:
+	explicit MergeSorter(Container& container) noexcept;
+	MergeSorter(const MergeSorter& mergeSorter) noexcept = delete;
+	MergeSorter(MergeSorter&& mergeSorter) noexcept = delete;
+	~MergeSorter() noexcept override = default;
+
+public:
+	MergeSorter& operator=(const MergeSorter& mergeSorter) noexcept = delete;
+	MergeSorter& operator=(MergeSorter&& mergeSorter) noexcept = delete;
+
+public:
+	virtual void sort(const std::function<bool(const typename Container::value_type&,
+	                                           const typename Container::value_type&)>& predicate) noexcept override;
+
+private:
+	template<typename Iterator>
+	void mergeSort(Iterator begin,
+	               Iterator end,
+	               const std::function<bool(const typename Container::value_type&,
+	                                        const typename Container::value_type&)>& predicate) noexcept;
+	
+	template<typename Iterator>
+	void merge(Iterator begin,
+	           Iterator middle,
+	           Iterator end,
+	           const std::function<bool(const typename Container::value_type&,
+	                                    const typename Container::value_type&)>& predicate) noexcept;
+
+private:
+	Container& container;
+};
+
+template<ArrayOrVectorConcept Container>
+MergeSorter<Container>::MergeSorter(Container& container) noexcept :
+		SortingAlgorithm<typename Container::value_type> {}, container {container} {
+	
+}
+
+template<ArrayOrVectorConcept Container>
+void MergeSorter<Container>::sort(const std::function<bool(const typename Container::value_type&,
+                                                           const typename Container::value_type&)>& predicate) noexcept {
+	mergeSort(container.begin(), container.end(), predicate);
+}
+
+template<ArrayOrVectorConcept Container>
+template<typename Iterator>
+void MergeSorter<Container>::mergeSort(Iterator begin,
+                                       Iterator end,
+                                       const std::function<bool(const typename Container::value_type&,
+                                                                const typename Container::value_type&)>& predicate) noexcept {
+	const auto size {std::distance(begin, end)};
+	if (size < 2) {
+		return;
+	}
+	
+	const auto offsetToMiddle {size / 2};
+	auto middle {std::next(begin, offsetToMiddle)};
+	
+	mergeSort(begin, middle, predicate);
+	mergeSort(middle, end, predicate);
+	
+	merge(begin, middle, end, predicate);
+}
+
+template<ArrayOrVectorConcept Container>
+template<typename Iterator>
+void MergeSorter<Container>::merge(Iterator begin,
+                                   Iterator middle,
+                                   Iterator end,
+                                   const std::function<bool(const typename Container::value_type&,
+                                                            const typename Container::value_type&)>& predicate) noexcept {
+	auto buffer {std::vector<typename std::iterator_traits<Iterator>::value_type> {begin, end}};
+	auto leftIterator {buffer.begin()};
+	auto rightIterator {buffer.begin() + (middle - begin)};
+	auto leftEnd {rightIterator};
+	auto rightEnd {buffer.end()};
+	auto currentIterator {begin};
+	
+	while (leftIterator != leftEnd && rightIterator != rightEnd) {
+		*currentIterator = predicate(*leftIterator, *rightIterator) ? *leftIterator++ : *rightIterator++;
+		++currentIterator;
+	}
+	
+	std::copy(leftIterator, leftEnd, currentIterator);
+	std::copy(rightIterator, rightEnd, currentIterator);
+}
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ implementing algorithms and data structures in C++, particularly with a focus on
 - Sorting
     - Bubble Sort
     - Insertion Sort
+    - Merge Sort
 
 ### Data Structures
 

--- a/Test/Source/Algorithms/Sorting/CMakeLists.txt
+++ b/Test/Source/Algorithms/Sorting/CMakeLists.txt
@@ -2,6 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.26)
 
 SET(SOURCE_FILES
 		BubbleSorterTest.cpp
-		InsertionSorterTest.cpp)
+		InsertionSorterTest.cpp
+		MergeSorterTest.cpp)
 
 TARGET_SOURCES(${PROJECT_NAME} PRIVATE ${SOURCE_FILES})

--- a/Test/Source/Algorithms/Sorting/MergeSorterTest.cpp
+++ b/Test/Source/Algorithms/Sorting/MergeSorterTest.cpp
@@ -1,0 +1,59 @@
+#include <gmock/gmock.h>
+
+#include "Algorithms/Sorting/MergeSorter.hpp"
+#include "UnsortedIntegerData.hpp"
+#include "UnsortedStringData.hpp"
+
+namespace Core::Algorithms::Sorting::Test {
+TEST(MergeSorterTest, GivenUnsortedIntegerArray_WhenSortAscendingOrder_ThenArrayIsSortedInAscendingOrder) {
+	std::array<int, 10> unsortedData {unsortedIntegers};
+	auto mergeSorter {MergeSorter<std::array<int, 10>>(unsortedData)};
+	mergeSorter.sort(std::less<int> {});
+	
+	EXPECT_THAT(unsortedData, testing::ElementsAre(1, 6, 23, 29, 34, 45, 73, 88, 99, 100));
+}
+
+TEST(MergeSorterTest, GivenUnsortedIntegerVector_WhenSortDescendingOrder_ThenArrayIsSortedInDescendingOrder) {
+	std::vector<int> unsortedData {unsortedIntegers.begin(), unsortedIntegers.end()};
+	auto mergeSorter {MergeSorter<std::vector<int>>(unsortedData)};
+	mergeSorter.sort(std::greater<int> {});
+	
+	EXPECT_THAT(unsortedData, testing::ElementsAre(100, 99, 88, 73, 45, 34, 29, 23, 6, 1));
+}
+
+TEST(MergeSorterTest, GivenUnsortedStringArray_WhenSortAscendingOrder_ThenArrayIsSortedInAscendingOrder) {
+	std::array<std::string, 10> unsortedData {unsortedStrings};
+	auto mergeSorter {MergeSorter<std::array<std::string, 10>>(unsortedData)};
+	mergeSorter.sort(std::less<std::string> {});
+	
+	EXPECT_THAT(unsortedData,
+	            testing::ElementsAre("!",
+	                                 "Apple",
+	                                 "Banana",
+	                                 "Cherry",
+	                                 "Grape",
+	                                 "Melon",
+	                                 "Orange",
+	                                 "Peach",
+	                                 "Pear",
+	                                 "Strawberry"));
+}
+
+TEST(MergeSorterTest, GivenUnsortedStringVector_WhenSortDescendingOrder_ThenVectorIsSortedInDescendingOrder) {
+	std::vector<std::string> unsortedData {unsortedStrings.begin(), unsortedStrings.end()};
+	auto mergeSorter {MergeSorter<std::vector<std::string>>(unsortedData)};
+	mergeSorter.sort(std::greater<std::string> {});
+	
+	EXPECT_THAT(unsortedData,
+	            testing::ElementsAre("Strawberry",
+	                                 "Pear",
+	                                 "Peach",
+	                                 "Orange",
+	                                 "Melon",
+	                                 "Grape",
+	                                 "Cherry",
+	                                 "Banana",
+	                                 "Apple",
+	                                 "!"));
+}
+}


### PR DESCRIPTION
# Overview
A generic implementation of merge sort utilizing iterators. Only two collections can be used with the merge sorter, `std::array` and `std::vector`.